### PR TITLE
feat: Add iCloud backup functionality

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -43,7 +43,18 @@ const config = () => ({
       output: 'static',
       favicon: './assets/images/favicon.png',
     },
-    plugins: ['expo-router', 'expo-font', 'expo-sqlite', 'expo-image-picker'],
+    plugins: [
+      'expo-router',
+      'expo-font',
+      'expo-sqlite',
+      'expo-image-picker',
+      [
+        'react-native-cloud-storage',
+        {
+          iCloudContainerEnvironment: 'Production',
+        },
+      ],
+    ],
     experiments: {
       typedRoutes: true,
     },
@@ -52,7 +63,7 @@ const config = () => ({
         origin: false,
       },
       eas: {
-        projectId: '',
+        projectId: '499e5b8b-b2bb-46a4-a6fc-dafaa25c7049',
       },
     },
   },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@ import migrations from '@/db/migrations/migrations'
 import { seedDatabase } from '@/db/seed'
 import Toast from '@/shared/components/Toast'
 import Context from '@/shared/context'
+import { performDailyBackupIfNeeded } from '@/shared/icloud'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -40,9 +41,11 @@ const AppWrapper = () => {
 
   useEffect(() => {
     if (success) {
-      seedDatabase().then(() => {
-        SplashScreen.hideAsync()
-      })
+      seedDatabase()
+        .then(() => performDailyBackupIfNeeded())
+        .then(() => {
+          SplashScreen.hideAsync()
+        })
     }
   }, [success])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-native": "0.76.9",
+        "react-native-cloud-storage": "^2.3.0",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-get-random-values": "^1.11.0",
         "react-native-paper": "^5.14.5",
@@ -13650,6 +13651,22 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-cloud-storage": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-cloud-storage/-/react-native-cloud-storage-2.3.0.tgz",
+      "integrity": "sha512-Bt+vnHO5Ae/ITMpZfySOxSVQckPKMb8ZQ0IXsSR7+y+AnShtlTbQ08qEYlHCXOp6+NGAhGD5ushqYO4nrd18tg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": ">=48.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.9",
+    "react-native-cloud-storage": "^2.3.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-get-random-values": "^1.11.0",
     "react-native-paper": "^5.14.5",

--- a/shared/icloud.ts
+++ b/shared/icloud.ts
@@ -1,0 +1,219 @@
+import { Platform } from 'react-native'
+import { CloudStorage } from 'react-native-cloud-storage'
+
+import { db } from '@/db/client'
+import { deleteAllData } from '@/db/queries/delete'
+import { insertCamera, insertRoll, insertRollPhoto } from '@/db/queries/insert'
+import {
+  CameraRunType,
+  CamerasTable,
+  RollPhotoRunType,
+  RollPhotosTable,
+  RollRunType,
+  RollsTable,
+  type SelectCamera,
+  type SelectRoll,
+  type SelectRollPhoto,
+} from '@/db/schema'
+
+import { getValueFromKeyStore, saveValueToKeyStore } from './utilities'
+
+const ICLOUD_BACKUP_ENABLED_KEY = 'icloud_backup_enabled'
+const ICLOUD_LAST_BACKUP_KEY = 'icloud_last_backup_timestamp'
+const BACKUP_FILENAME = 'filmtracker-backup.json'
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+export const isIOS = Platform.OS === 'ios'
+
+export async function getICloudBackupEnabled(): Promise<boolean> {
+  if (!isIOS) return false
+  const value = await getValueFromKeyStore(ICLOUD_BACKUP_ENABLED_KEY)
+  return value === 'true'
+}
+
+export async function setICloudBackupEnabled(enabled: boolean): Promise<void> {
+  await saveValueToKeyStore(
+    ICLOUD_BACKUP_ENABLED_KEY,
+    enabled ? 'true' : 'false'
+  )
+}
+
+export async function getLastBackupTimestamp(): Promise<number | null> {
+  const value = await getValueFromKeyStore(ICLOUD_LAST_BACKUP_KEY)
+  return value ? parseInt(value, 10) : null
+}
+
+async function setLastBackupTimestamp(timestamp: number): Promise<void> {
+  await saveValueToKeyStore(ICLOUD_LAST_BACKUP_KEY, timestamp.toString())
+}
+
+export async function isBackupNeeded(): Promise<boolean> {
+  const enabled = await getICloudBackupEnabled()
+  if (!enabled) return false
+
+  const lastBackup = await getLastBackupTimestamp()
+  if (!lastBackup) return true
+
+  const now = Date.now()
+  return now - lastBackup >= ONE_DAY_MS
+}
+
+export async function checkICloudAvailable(): Promise<boolean> {
+  if (!isIOS) return false
+  try {
+    return await CloudStorage.isCloudAvailable()
+  } catch {
+    return false
+  }
+}
+
+export async function backupToICloud(): Promise<{
+  success: boolean
+  error?: string
+}> {
+  if (!isIOS) {
+    return { success: false, error: 'iCloud backup is only available on iOS' }
+  }
+
+  try {
+    const available = await CloudStorage.isCloudAvailable()
+    if (!available) {
+      return { success: false, error: 'iCloud is not available' }
+    }
+
+    const cameras = await db.select().from(CamerasTable)
+    const rolls = await db.select().from(RollsTable)
+    const rollPhotos = await db.select().from(RollPhotosTable)
+
+    const backupData = JSON.stringify({
+      cameras,
+      rolls,
+      rollPhotos,
+      backupDate: new Date().toISOString(),
+    })
+
+    await CloudStorage.writeFile(BACKUP_FILENAME, backupData)
+    await setLastBackupTimestamp(Date.now())
+
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+export async function getICloudBackupInfo(): Promise<{
+  exists: boolean
+  backupDate?: string
+  error?: string
+}> {
+  if (!isIOS) {
+    return { exists: false, error: 'iCloud is only available on iOS' }
+  }
+
+  try {
+    const available = await CloudStorage.isCloudAvailable()
+    if (!available) {
+      return { exists: false, error: 'iCloud is not available' }
+    }
+
+    const fileExists = await CloudStorage.exists(BACKUP_FILENAME)
+    if (!fileExists) {
+      return { exists: false }
+    }
+
+    const content = await CloudStorage.readFile(BACKUP_FILENAME)
+    const data = JSON.parse(content)
+
+    return {
+      exists: true,
+      backupDate: data.backupDate,
+    }
+  } catch {
+    return { exists: false }
+  }
+}
+
+export async function restoreFromICloud(): Promise<{
+  success: boolean
+  error?: string
+  restoredCameras?: number
+  restoredRolls?: number
+  restoredPhotos?: number
+}> {
+  if (!isIOS) {
+    return { success: false, error: 'iCloud restore is only available on iOS' }
+  }
+
+  try {
+    const available = await CloudStorage.isCloudAvailable()
+    if (!available) {
+      return { success: false, error: 'iCloud is not available' }
+    }
+
+    const fileExists = await CloudStorage.exists(BACKUP_FILENAME)
+    if (!fileExists) {
+      return { success: false, error: 'No iCloud backup found' }
+    }
+
+    const content = await CloudStorage.readFile(BACKUP_FILENAME)
+    const {
+      cameras: rawCameras,
+      rolls: rawRolls,
+      rollPhotos: rawRollPhotos,
+    } = JSON.parse(content)
+
+    if (
+      !Array.isArray(rawCameras) ||
+      !Array.isArray(rawRolls) ||
+      !Array.isArray(rawRollPhotos)
+    ) {
+      return { success: false, error: 'Invalid backup file format' }
+    }
+
+    const cameras: SelectCamera[] = rawCameras.map(camera =>
+      CameraRunType.check(camera)
+    )
+    const rolls: SelectRoll[] = rawRolls.map(roll => RollRunType.check(roll))
+    const rollPhotos: SelectRollPhoto[] = rawRollPhotos.map(photo =>
+      RollPhotoRunType.check(photo)
+    )
+
+    await deleteAllData()
+
+    for (const camera of cameras) {
+      await insertCamera(camera)
+    }
+    for (const roll of rolls) {
+      await insertRoll(roll)
+    }
+    for (const photo of rollPhotos) {
+      await insertRollPhoto(photo)
+    }
+
+    return {
+      success: true,
+      restoredCameras: cameras.length,
+      restoredRolls: rolls.length,
+      restoredPhotos: rollPhotos.length,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+export async function performDailyBackupIfNeeded(): Promise<void> {
+  try {
+    const needed = await isBackupNeeded()
+    if (needed) {
+      await backupToICloud()
+    }
+  } catch {
+    // Silently fail for automatic backups
+  }
+}


### PR DESCRIPTION
## Summary
- Add `react-native-cloud-storage` for iCloud integration
- Create `shared/icloud.ts` with backup/restore functions for cameras, rolls, and roll photos
- Add iOS-only iCloud backup section in Settings with toggle for auto-backup and restore button
- Enable automatic daily backups on app startup (checks if 24+ hours since last backup)

## Changes
- `shared/icloud.ts` - New file with all iCloud backup logic
- `app/settings.tsx` - Added iCloud Backup section (iOS only)
- `app/_layout.tsx` - Call `performDailyBackupIfNeeded()` on startup
- `app.config.js` - Added `react-native-cloud-storage` plugin
- `package.json` - Added `react-native-cloud-storage` dependency

## Test plan
- [ ] Run `npx expo prebuild` to verify config
- [ ] Test on iOS simulator/device
- [ ] Toggle iCloud backup on/off
- [ ] Verify backup creates file in iCloud
- [ ] Test restore from iCloud
- [ ] Verify iCloud section is hidden on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)