### PR TITLE
fix: Regenerate database migrations to fix missing columns

### DIFF
--- a/app/add-roll.tsx
+++ b/app/add-roll.tsx
@@ -57,7 +57,8 @@ export default function AddRoll() {
         payload: { message: 'Roll added', variant: 'SUCCESS' },
       })
       router.back()
-    } catch (_error) {
+    } catch (error) {
+      console.error('Failed to add roll:', error)
       dispatch({
         type: 'TOAST',
         payload: { message: 'Failed to add roll', variant: 'ERROR' },

--- a/db/migrations/0000_omniscient_wrecker.sql
+++ b/db/migrations/0000_omniscient_wrecker.sql
@@ -22,14 +22,18 @@ CREATE TABLE `roll` (
 	`id` text PRIMARY KEY NOT NULL,
 	`cameraId` text NOT NULL,
 	`filmStock` text NOT NULL,
-	`status` text DEFAULT 'IN_CAMERA' NOT NULL,
+	`status` text DEFAULT 'EXPOSING' NOT NULL,
 	`frameCount` integer DEFAULT 36 NOT NULL,
 	`framesShot` integer,
+	`iso` integer,
 	`notes` text,
 	`createdAt` text NOT NULL,
 	`updatedAt` text,
-	`startedAt` text,
+	`exposingAt` text,
+	`exposedAt` text,
 	`developedAt` text,
+	`archivedAt` text,
+	`abandonedAt` text,
 	FOREIGN KEY (`cameraId`) REFERENCES `camera`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint

--- a/db/migrations/0001_add_iso.sql
+++ b/db/migrations/0001_add_iso.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `roll` ADD `iso` integer;

--- a/db/migrations/0002_status_dates.sql
+++ b/db/migrations/0002_status_dates.sql
@@ -1,4 +1,0 @@
-ALTER TABLE `roll` ADD `exposingAt` text;
-ALTER TABLE `roll` ADD `exposedAt` text;
-ALTER TABLE `roll` ADD `archivedAt` text;
-ALTER TABLE `roll` ADD `abandonedAt` text;

--- a/db/migrations/meta/0000_snapshot.json
+++ b/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "9190d457-d272-45e4-95b4-321b8f2d6543",
+  "id": "7ec3045c-74df-49f2-9786-a8e1c1015867",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "camera": {
@@ -163,7 +163,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'IN_CAMERA'"
+          "default": "'EXPOSING'"
         },
         "frameCount": {
           "name": "frameCount",
@@ -175,6 +175,13 @@
         },
         "framesShot": {
           "name": "framesShot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iso": {
+          "name": "iso",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
@@ -201,8 +208,15 @@
           "notNull": false,
           "autoincrement": false
         },
-        "startedAt": {
-          "name": "startedAt",
+        "exposingAt": {
+          "name": "exposingAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposedAt": {
+          "name": "exposedAt",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -210,6 +224,20 @@
         },
         "developedAt": {
           "name": "developedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abandonedAt": {
+          "name": "abandonedAt",
           "type": "text",
           "primaryKey": false,
           "notNull": false,

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -5,22 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1769401361749,
-      "tag": "0000_late_zaladane",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1769401361750,
-      "tag": "0001_add_iso",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1769401361751,
-      "tag": "0002_status_dates",
+      "when": 1769628384489,
+      "tag": "0000_omniscient_wrecker",
       "breakpoints": true
     }
   ]

--- a/db/migrations/migrations.js
+++ b/db/migrations/migrations.js
@@ -1,16 +1,12 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_late_zaladane.sql';
-import m0001 from './0001_add_iso.sql';
-import m0002 from './0002_status_dates.sql';
+import m0000 from './0000_omniscient_wrecker.sql';
 
   export default {
     journal,
     migrations: {
-      m0000,
-      m0001,
-      m0002
+      m0000
     }
   }
   


### PR DESCRIPTION
## Summary
- **Root cause**: Migration `0002_status_dates.sql` was hand-written without `--> statement-breakpoint` separators between its 4 `ALTER TABLE` statements. The drizzle migrator uses `prepareSync` (single-statement only) and splits on these markers, so all statements were passed as one string, causing `table roll has no column named exposedAt`.
- Regenerated all migrations from scratch via `drizzle-kit generate`, producing a single correct migration with all columns and proper breakpoints.
- Added `console.error` logging to the add-roll catch block so future database errors are visible in logs.

## Test plan
- [ ] Delete app from device/simulator
- [ ] Build and install fresh
- [ ] Verify seed data loads (migrations ran successfully)
- [ ] Add a new roll and confirm it saves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)