### PR TITLE
fix: Only seed sample data in development builds

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,7 +41,7 @@ const AppWrapper = () => {
 
   useEffect(() => {
     if (success) {
-      seedDatabase()
+      (__DEV__ ? seedDatabase() : Promise.resolve())
         .then(() => performDailyBackupIfNeeded())
         .then(() => {
           SplashScreen.hideAsync()


### PR DESCRIPTION
## Summary
- Gates `seedDatabase()` behind `__DEV__` so sample cameras and rolls are only inserted in development builds
- Production users will start with an empty database instead of getting Leica M6, Nikon F3, and Pentax K1000 sample data

## Test plan
- [ ] Run dev build — verify sample data still appears on fresh install
- [ ] Run production build — verify database starts empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)